### PR TITLE
Add panic recovery to wrapSvc

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -52,7 +52,8 @@ func main() {
 
 	sg.Add(&sleep.Sleep{
 		Id:      "sleep-8",
-		Pass:    false,
+		Pass:    true,
+		Panic:   true,
 		Seconds: 8,
 	})
 

--- a/examples/sleep/sleep.go
+++ b/examples/sleep/sleep.go
@@ -8,6 +8,7 @@ import (
 type Sleep struct {
 	Id      string
 	Pass    bool
+	Panic   bool
 	Seconds int
 	Quit    bool
 }
@@ -32,6 +33,9 @@ ctrl_loop:
 
 	if !s.Pass {
 		return fmt.Errorf("%s fail", s.Id)
+	}
+	if s.Panic {
+		panic(fmt.Sprintf("%s panic", s.Id))
 	}
 	return nil
 }


### PR DESCRIPTION
Recovers from a service panic. Attempts to cast to err/string if possible. A first stab.

Closes #6 

Some additional things that could be added:
- Print stack trace on panic
- Panic again upon return
- Allow panics as another means for "error"ing out of a service (json package has a similar technique for "unwinding" nested calls)