### PR TITLE
Add Option to Handle Sigint Directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ A list of services to start, watch for errors and properly exit all services in 
 `Wait`: ensures the main thread will block until all services in the ServiceGroup are done running
 `Kill`: force close everything in a ServiceGroup
 `Start`: starts all the services in the ServiceGroup
+`HandleSigint`: adds a handler to stop all services on SIGINT
 
 
 ## Other Notes
-
-Catching SIGNALS is left to the user of `Service`, and Call `Kill` to force all services in the group to stop.
 
 Each child routine is expected to return one error at most. Internally each routine's error channel is merged into an error channel that has a capacity equal to the number of child routines. If the child routines pass more errors than the number of child routines the channel will fill up and crash the program.
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 
 	"github.com/stephenrlouie/service"
 	"github.com/stephenrlouie/service/examples/hello"
@@ -12,21 +10,9 @@ import (
 
 func main() {
 	sg := service.New()
-
-	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt)
-
-	go func() {
-	ctrl_loop:
-		for {
-			select {
-			case <-signals:
-				fmt.Printf("SIGINT Received. Shutting down...\n")
-				break ctrl_loop
-			}
-		}
-		sg.Kill()
-	}()
+	sg.HandleSigint(func() {
+		fmt.Printf("SIGINT Received. Shutting down...\n")
+	})
 
 	sg.Add(&hello.Hello{
 		Id: "hello",


### PR DESCRIPTION
This PR adds the ability for the services package to handle sigints directly. 
Most implementations currently add signal handling directly before using this package (creating an extra goroutine/channel listener) -- this removes the need for that by adding a case to the existing channel switch. 

Usage: 
```	serviceGroup := service.New()
	serviceGroup.HandleSigint(nil)
        /* or serviceGroup.HandleSigint(func() { fmt.Println("GOT SIGINT, QUITTING") }) */
	serviceGroup.Add(/* something */)
	serviceGroup.Start()
	serviceGroup.Wait()
```